### PR TITLE
feat: dry run support

### DIFF
--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -12,6 +12,8 @@ const CHECK_FILE_PATH_ARG_LONG: &str = "check-file-path";
 const CHECK_FILE_PATH_ARG_SHORT: char = 'f';
 const URL_ENDPOINT_ARG_LONG: &str = "url-endpoint";
 const URL_ENDPOINT_ARG_SHORT: char = 'u';
+const DRY_RUN_ARG_LONG: &str = "dry";
+const DRY_RUN_ARG_SHORT: char = 'd';
 
 #[derive(Debug, Parser)]
 pub struct ArgsPartialConfigProvider {
@@ -23,6 +25,8 @@ pub struct ArgsPartialConfigProvider {
     pub check_file_path: Option<String>,
     #[clap(long = URL_ENDPOINT_ARG_LONG, short = URL_ENDPOINT_ARG_SHORT)]
     pub url_endpoint: Option<String>,
+    #[clap(long = DRY_RUN_ARG_LONG, short = DRY_RUN_ARG_SHORT)]
+    pub dry_run: Option<bool>,
 }
 
 #[async_trait]
@@ -33,6 +37,7 @@ impl PartialConfigProvider for ArgsPartialConfigProvider {
             chat_id: self.chat_id.to_owned(),
             check_file_path: self.check_file_path.to_owned(),
             url_endpoint: self.url_endpoint.to_owned(),
+            dry_run: self.dry_run,
         }
     }
 }

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -26,7 +26,7 @@ pub struct ArgsPartialConfigProvider {
     #[clap(long = URL_ENDPOINT_ARG_LONG, short = URL_ENDPOINT_ARG_SHORT)]
     pub url_endpoint: Option<String>,
     #[clap(long = DRY_RUN_ARG_LONG, short = DRY_RUN_ARG_SHORT)]
-    pub dry_run: Option<bool>,
+    pub dry_run: bool,
 }
 
 #[async_trait]
@@ -37,7 +37,7 @@ impl PartialConfigProvider for ArgsPartialConfigProvider {
             chat_id: self.chat_id.to_owned(),
             check_file_path: self.check_file_path.to_owned(),
             url_endpoint: self.url_endpoint.to_owned(),
-            dry_run: self.dry_run,
+            dry_run: Some(self.dry_run),
         }
     }
 }

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -22,6 +22,8 @@ impl PartialConfigProvider for EnvPartialConfigProvider {
             chat_id,
             check_file_path,
             url_endpoint,
+            // Dry run can only be passed as a CLI argument, not as an env
+            dry_run: None,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,6 +18,7 @@ pub struct PartialConfig {
     pub chat_id: Option<String>,
     pub check_file_path: Option<String>,
     pub url_endpoint: Option<String>,
+    pub dry_run: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -26,6 +27,7 @@ pub struct Config {
     pub chat_id: String,
     pub check_file_path: String,
     pub url_endpoint: Option<String>,
+    pub dry_run: bool,
 }
 
 pub struct ArgsOrEnvConfigProvider;
@@ -49,12 +51,14 @@ impl ConfigProvider for ArgsOrEnvConfigProvider {
             .or(envs.check_file_path)
             .expect("No CHECK_FILE_PATH specified.");
         let url_endpoint = args.url_endpoint.or(envs.url_endpoint);
+        let dry_run = args.dry_run.or(envs.dry_run).unwrap_or(false);
 
         Config {
             tg_token,
             chat_id,
             check_file_path,
             url_endpoint,
+            dry_run,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,9 @@ pub async fn main() -> Result<(), &'static str> {
         new_attempt.last_delivery_success = true;
     }
 
-    attempt_storage.save_new_attempt(new_attempt).await;
+    if !config.dry_run {
+        attempt_storage.save_new_attempt(new_attempt).await;
+    }
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub async fn main() -> Result<(), &'static str> {
     };
 
     if config.dry_run {
+        println!("Dry run detected. Execution is stopping here and will not send a notification nor update the local info.");
         return Ok(());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,15 +42,17 @@ pub async fn main() -> Result<(), &'static str> {
         last_delivery_success: false,
     };
 
+    if config.dry_run {
+        return Ok(());
+    }
+
     let delivery_result = telegram_notifier.notify_ip_change(new_ip_address).await;
 
     if delivery_result.is_ok() {
         new_attempt.last_delivery_success = true;
     }
 
-    if !config.dry_run {
-        attempt_storage.save_new_attempt(new_attempt).await;
-    }
+    attempt_storage.save_new_attempt(new_attempt).await;
 
     Ok(())
 }


### PR DESCRIPTION
Fixes https://github.com/ntn-x2/ipmn/issues/7 by adding a new `--dry` and `-d` flags that will not send a notification nor update the local info about the latest IP fetch attempt.