### PR TITLE
feat: add support for choosing a bind address for the request

### DIFF
--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -14,6 +14,8 @@ const URL_ENDPOINT_ARG_LONG: &str = "url-endpoint";
 const URL_ENDPOINT_ARG_SHORT: char = 'u';
 const DRY_RUN_ARG_LONG: &str = "dry";
 const DRY_RUN_ARG_SHORT: char = 'd';
+const BIND_ADDRESS_ARG_LONG: &str = "bind-address";
+const BIND_ADDRESS_ARG_SHORT: char = 'b';
 
 #[derive(Debug, Parser)]
 pub struct ArgsPartialConfigProvider {
@@ -27,6 +29,8 @@ pub struct ArgsPartialConfigProvider {
     pub url_endpoint: Option<String>,
     #[clap(long = DRY_RUN_ARG_LONG, short = DRY_RUN_ARG_SHORT)]
     pub dry_run: bool,
+    #[clap(long = BIND_ADDRESS_ARG_LONG, short = BIND_ADDRESS_ARG_SHORT)]
+    pub bind_address: Option<String>,
 }
 
 #[async_trait]
@@ -38,6 +42,7 @@ impl PartialConfigProvider for ArgsPartialConfigProvider {
             check_file_path: self.check_file_path.to_owned(),
             url_endpoint: self.url_endpoint.to_owned(),
             dry_run: Some(self.dry_run),
+            bind_address: self.bind_address.to_owned(),
         };
         log::trace!("Arguments passed from the command line: {:?}", config);
         config

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -24,6 +24,8 @@ impl PartialConfigProvider for EnvPartialConfigProvider {
             url_endpoint,
             // Dry run can only be passed as a CLI argument, not as an env
             dry_run: None,
+            // Bind address can only be passed as a CLI argument, not as an env
+            bind_address: None,
         };
         log::trace!("Arguments passed from the environment: {:?}", config);
         config

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,6 +19,7 @@ pub struct PartialConfig {
     pub check_file_path: Option<String>,
     pub url_endpoint: Option<String>,
     pub dry_run: Option<bool>,
+    pub bind_address: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -28,6 +29,7 @@ pub struct Config {
     pub check_file_path: String,
     pub url_endpoint: Option<String>,
     pub dry_run: bool,
+    pub bind_address: Option<String>,
 }
 
 pub struct ArgsOrEnvConfigProvider;
@@ -52,6 +54,7 @@ impl ConfigProvider for ArgsOrEnvConfigProvider {
             .expect("No CHECK_FILE_PATH specified.");
         let url_endpoint = args.url_endpoint.or(envs.url_endpoint);
         let dry_run = args.dry_run.or(envs.dry_run).unwrap_or(false);
+        let bind_address = args.bind_address.or(envs.bind_address);
 
         let config = Config {
             tg_token,
@@ -59,6 +62,7 @@ impl ConfigProvider for ArgsOrEnvConfigProvider {
             check_file_path,
             url_endpoint,
             dry_run,
+            bind_address,
         };
         log::info!(
             "Arguments passed from the command line and then the environment: {:?}",


### PR DESCRIPTION
Adds a new `--bind-address <IPv4 address>` or `-b <IPv4 address` option to the executable, which allows to choose which local IP address (hence which interface) to use when fetching the public IP address.